### PR TITLE
Fix min requirement

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,5 +9,5 @@ dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=1.0.0 <3.0.0"
+  sdk: ">=1.19.0 <3.0.0"
   flutter: ">=0.4.4 <2.0.0"


### PR DESCRIPTION
Argh.  Pub publish complains because the min SDK requirement to support flutter is 1.19.0.  Updated.

TBR= @cbracken